### PR TITLE
Improve responsive zoom

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -185,12 +185,24 @@ select:focus {
   width: 100%;
 }
 
-#sankey-diagram {
+#zoom-wrapper {
   width: 100%;
   height: 85vh;
   min-height: 600px;
   border-radius: 12px;
   overflow: hidden;
+  touch-action: none;
+  transform-origin: 0 0;
+  cursor: grab;
+}
+
+#zoom-wrapper.dragging {
+  cursor: grabbing;
+}
+
+#sankey-diagram {
+  width: 100%;
+  height: 100%;
 }
 
 /* Responsive design */
@@ -216,9 +228,9 @@ select:focus {
     padding: 15px;
   }
 
-  #sankey-diagram {
+  #zoom-wrapper {
     height: 75vh;
-    min-height: 500px;
+    min-height: 400px;
   }
 }
 
@@ -236,9 +248,9 @@ select:focus {
     padding: 12px;
   }
 
-  #sankey-diagram {
+  #zoom-wrapper {
     height: 70vh;
-    min-height: 450px;
+    min-height: 320px;
   }
 
   select {
@@ -420,6 +432,17 @@ select:focus {
   background: #0056b3;
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(0, 123, 255, 0.3);
+}
+
+.reset-btn {
+  background: #17a2b8;
+  color: white;
+}
+
+.reset-btn:hover {
+  background: #138496;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(23, 162, 184, 0.3);
 }
 
 .export-btn:disabled {

--- a/public/index.html
+++ b/public/index.html
@@ -54,17 +54,22 @@
             <button id="export-png-btn" class="export-btn png-btn" aria-label="Exportar como PNG">
               📷 PNG
             </button>
-            <button id="export-svg-btn" class="export-btn svg-btn" aria-label="Exportar como SVG">
+          <button id="export-svg-btn" class="export-btn svg-btn" aria-label="Exportar como SVG">
               📄 SVG
-            </button>
-          </div>
+          </button>
+          <button id="reset-view-btn" class="export-btn reset-btn" aria-label="Restablecer vista">
+            🔄 Restablecer
+          </button>
+        </div>
         </div>
       </section>
 
       <!-- Diagram Section -->
       <section class="diagram-section">
         <div class="diagram-container">
-          <div id="sankey-diagram" role="img" aria-label="Diagrama de Sankey del Balance Nacional de Energía"></div>
+          <div id="zoom-wrapper" class="zoom-wrapper">
+            <div id="sankey-diagram" role="img" aria-label="Diagrama de Sankey del Balance Nacional de Energía"></div>
+          </div>
         </div>
       </section>
     </main>
@@ -175,6 +180,7 @@
     <script src="js/PopupManager.js"></script>
     <script src="js/ExportManager.js"></script>
     <script src="js/ColumnLabelsManager.js"></script>
+    <script src="js/ZoomManager.js"></script>
     <script src="js/main.js"></script>
   </body>
 </html>

--- a/public/js/ZoomManager.js
+++ b/public/js/ZoomManager.js
@@ -1,0 +1,137 @@
+class ZoomManager {
+  constructor(container, options = {}) {
+    this.container = container;
+    this.target = options.target || container;
+    this.scale = 1;
+    // Prevent zooming out below the initial size unless explicitly specified
+    this.minScale = options.minScale || 1;
+    this.maxScale = options.maxScale || 3;
+    this.translateX = 0;
+    this.translateY = 0;
+    this.isDragging = false;
+    this.startX = 0;
+    this.startY = 0;
+    this.activePointers = new Map();
+    this.attachEvents();
+    this.applyTransform();
+  }
+
+  setContainer(container) {
+    this.container = container;
+    this.applyTransform();
+  }
+
+  setTarget(target) {
+    this.target = target;
+    this.applyTransform();
+  }
+
+  attachEvents() {
+    this.container.addEventListener('wheel', this.onWheel.bind(this), { passive: false });
+    this.container.addEventListener('pointerdown', this.onPointerDown.bind(this));
+    window.addEventListener('pointermove', this.onPointerMove.bind(this));
+    window.addEventListener('pointerup', this.onPointerUp.bind(this));
+    window.addEventListener('pointercancel', this.onPointerUp.bind(this));
+    this.container.addEventListener('dblclick', () => this.reset());
+  }
+
+  onWheel(e) {
+    e.preventDefault();
+    const rect = this.container.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    const offsetY = e.clientY - rect.top;
+    // Slightly larger zoom steps for a snappier feel
+    const factor = e.deltaY < 0 ? 1.2 : 0.8;
+    this.zoomAt(offsetX, offsetY, factor);
+  }
+
+  zoomAt(x, y, factor) {
+    const newScale = Math.min(this.maxScale, Math.max(this.minScale, this.scale * factor));
+    this.translateX -= (x / this.scale - x / newScale);
+    this.translateY -= (y / this.scale - y / newScale);
+    this.scale = newScale;
+    this.applyTransform();
+  }
+
+  onPointerDown(e) {
+    this.activePointers.set(e.pointerId, e);
+    if (this.activePointers.size === 1) {
+      this.isDragging = true;
+      this.startX = e.clientX;
+      this.startY = e.clientY;
+      this.container.classList.add('dragging');
+    } else if (this.activePointers.size === 2) {
+      const pts = Array.from(this.activePointers.values());
+      this.initialPinchDistance = this.distance(pts[0], pts[1]);
+      this.initialScale = this.scale;
+      this.isDragging = false;
+    }
+  }
+
+  onPointerMove(e) {
+    if (!this.activePointers.has(e.pointerId)) return;
+    this.activePointers.set(e.pointerId, e);
+    if (this.activePointers.size === 2) {
+      const pts = Array.from(this.activePointers.values());
+      const currentDistance = this.distance(pts[0], pts[1]);
+      const factor = currentDistance / this.initialPinchDistance;
+      const newScale = Math.min(this.maxScale, Math.max(this.minScale, this.initialScale * factor));
+      const rect = this.container.getBoundingClientRect();
+      const cx = (pts[0].clientX + pts[1].clientX) / 2 - rect.left;
+      const cy = (pts[0].clientY + pts[1].clientY) / 2 - rect.top;
+      this.translateX -= (cx / this.scale - cx / newScale);
+      this.translateY -= (cy / this.scale - cy / newScale);
+      this.scale = newScale;
+      this.applyTransform();
+    } else if (this.isDragging) {
+      const dx = (e.clientX - this.startX) / this.scale;
+      const dy = (e.clientY - this.startY) / this.scale;
+      this.startX = e.clientX;
+      this.startY = e.clientY;
+      this.translateX += dx;
+      this.translateY += dy;
+      this.applyTransform();
+    }
+  }
+
+  onPointerUp(e) {
+    this.activePointers.delete(e.pointerId);
+    if (this.activePointers.size < 2) {
+      this.initialPinchDistance = null;
+    }
+    if (this.activePointers.size === 0) {
+      this.isDragging = false;
+      this.container.classList.remove('dragging');
+    }
+  }
+
+  distance(p1, p2) {
+    const dx = p1.clientX - p2.clientX;
+    const dy = p1.clientY - p2.clientY;
+    return Math.hypot(dx, dy);
+  }
+
+  applyTransform() {
+    const transform = `translate(${this.translateX}px, ${this.translateY}px) scale(${this.scale})`;
+    this.target.style.transform = transform;
+  }
+
+  reset() {
+    this.scale = 1;
+    this.translateX = 0;
+    this.translateY = 0;
+    this.applyTransform();
+  }
+
+  zoomIn() {
+    this.zoomAt(this.container.clientWidth / 2, this.container.clientHeight / 2, 1.2);
+  }
+
+  zoomOut() {
+    this.zoomAt(this.container.clientWidth / 2, this.container.clientHeight / 2, 0.8);
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = ZoomManager;
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,5 +1,6 @@
 const yearSelector = document.getElementById("year-selector");
 const sankeyDiv = document.getElementById("sankey-diagram");
+const zoomWrapperDiv = document.getElementById("zoom-wrapper");
 let dataManager = null;
 let styleManager = null;
 let layoutEngine = null;
@@ -8,6 +9,7 @@ let linkManager = null;
 let popupManager = null;
 let exportManager = null;
 let columnLabelsManager = null;
+let zoomManager = null;
 
 // Minimum link thickness added to each value after logarithmic scaling
 const MIN_LINK_SIZE = 0.25;
@@ -434,6 +436,12 @@ function clearAllLabels() {
 // Initialize export controls when DOM is ready
 document.addEventListener("DOMContentLoaded", () => {
   initializeExportControls();
+  const resetBtn = document.getElementById("reset-view-btn");
+  if (resetBtn) {
+    resetBtn.addEventListener("click", () => {
+      if (zoomManager) zoomManager.reset();
+    });
+  }
 });
 
 // Función para actualizar el diagrama de Sankey (Etapa 1.7: Añadir Salidas Completas)
@@ -3847,6 +3855,12 @@ function updateSankey(year) {
 
   Plotly.newPlot(sankeyDiv, [data], layout, config)
     .then(() => {
+      if (!zoomManager) {
+        zoomManager = new ZoomManager(zoomWrapperDiv, {
+          target: sankeyDiv,
+          minScale: 1,
+        });
+      }
       // Renderizar etiquetas de columnas después de que el diagrama esté listo
       if (columnLabelsManager && columnLabelsManager.isEnabled()) {
         // Usar setTimeout para asegurar que el diagrama esté completamente renderizado


### PR DESCRIPTION
## Summary
- tweak zoom step for snappier feel
- prevent zooming out beyond 100% by default
- adjust responsive min-height of zoom wrapper
- specify zoom initialization options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688961c023f0832fac57ad9b8d22b09b