### PR TITLE
Convert export modal to sliding panel

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -898,6 +898,65 @@ select:focus {
   margin-bottom: 5px;
 }
 
+/* Config Panel Styles */
+.config-panel {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+  background: rgba(255, 255, 255, 0.25);
+  backdrop-filter: blur(8px);
+  z-index: 2000;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease;
+}
+
+.config-panel.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.config-content {
+  background: #ffffff;
+  width: 450px;
+  max-width: 90%;
+  height: 100%;
+  overflow-y: auto;
+  box-shadow: -4px 0 16px rgba(0, 0, 0, 0.2);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  position: relative;
+}
+
+.config-panel.visible .config-content {
+  transform: translateX(0);
+}
+
+.config-close-btn {
+  position: absolute;
+  top: 20px;
+  right: 25px;
+  background: none;
+  border: none;
+  font-size: 2rem;
+  color: #7f8c8d;
+  cursor: pointer;
+  z-index: 10;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.config-close-btn:hover {
+  background: #f8f9fa;
+  color: #2c3e50;
+}
+
 /* Flujo Steps */
 .flujo-steps {
   margin: 20px 0;
@@ -1032,6 +1091,16 @@ select:focus {
   .export-controls {
     justify-content: center;
   }
+
+  .config-panel {
+    padding: 0;
+  }
+
+  .config-content {
+    width: 100%;
+    max-width: 100%;
+    max-height: 95vh;
+  }
 }
 
 @media (max-width: 480px) {
@@ -1068,6 +1137,11 @@ select:focus {
   
   .importancia-item {
     padding: 15px;
+  }
+
+  .config-content {
+    width: 100%;
+    max-width: 100%;
   }
 }
 
@@ -1187,11 +1261,27 @@ select:focus {
     background: rgba(44, 62, 80, 0.95);
     border: 1px solid rgba(236, 240, 241, 0.1);
   }
+
+  .config-panel {
+    background: rgba(44, 62, 80, 0.4);
+  }
+  .config-content {
+    background: #2c3e50;
+    color: #ecf0f1;
+  }
+  .config-close-btn {
+    color: #bdc3c7;
+  }
+  .config-close-btn:hover {
+    background: #34495e;
+    color: #ecf0f1;
+  }
 }
 
 /* Accessibility improvements */
 .info-toggle-btn:focus,
-.info-close-btn:focus {
+.info-close-btn:focus,
+.config-close-btn:focus {
   outline: 2px solid #3498db;
   outline-offset: 2px;
 }
@@ -1199,6 +1289,7 @@ select:focus {
 /* Print styles */
 @media print {
   .info-panel,
+  .config-panel,
   .controls-section {
     display: none;
   }

--- a/public/index.html
+++ b/public/index.html
@@ -84,12 +84,12 @@
     </main>
 
     <!-- Modals -->
-    <!-- Export Configuration Modal -->
-    <div id="export-modal" class="modal" role="dialog" aria-labelledby="export-modal-title" aria-hidden="true">
-      <div class="modal-content">
+    <!-- Export Configuration Panel -->
+    <aside id="export-panel" class="config-panel" aria-labelledby="export-modal-title" aria-hidden="true">
+      <div class="config-content">
+        <button id="config-close-btn" class="config-close-btn" aria-label="Cerrar configuración">&times;</button>
         <div class="modal-header">
           <h3 id="export-modal-title">Configuración de Exportación</h3>
-          <button class="close" aria-label="Cerrar modal">&times;</button>
         </div>
         <div class="modal-body">
           <div class="config-section">
@@ -163,7 +163,7 @@
           <button id="cancel-config-btn" class="btn-secondary">Cancelar</button>
         </div>
       </div>
-    </div>
+    </aside>
 
     <!-- Export Progress Modal -->
     <div id="export-progress-modal" class="modal" role="dialog" aria-labelledby="progress-title" aria-hidden="true">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -177,32 +177,49 @@ function initializeExportControls() {
   const exportConfigBtn = document.getElementById("export-config-btn");
   const exportPngBtn = document.getElementById("export-png-btn");
   const exportSvgBtn = document.getElementById("export-svg-btn");
-  const exportModal = document.getElementById("export-modal");
+  const exportPanel = document.getElementById("export-panel");
   const exportProgressModal = document.getElementById("export-progress-modal");
-  const closeBtn = document.querySelector(".close");
+  const closeBtn = document.getElementById("config-close-btn");
   const saveConfigBtn = document.getElementById("save-config-btn");
   const cancelConfigBtn = document.getElementById("cancel-config-btn");
+
+  function hideExportPanel() {
+    exportPanel.classList.remove("visible");
+    exportPanel.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("info-open");
+  }
 
   // Open configuration modal
   exportConfigBtn.addEventListener("click", () => {
     loadConfigToModal();
-    exportModal.style.display = "block";
+    exportPanel.classList.add("visible");
+    exportPanel.setAttribute("aria-hidden", "false");
+    document.body.classList.add("info-open");
   });
 
   // Close modal events
   closeBtn.addEventListener("click", () => {
-    exportModal.style.display = "none";
+    hideExportPanel();
   });
 
   cancelConfigBtn.addEventListener("click", () => {
-    exportModal.style.display = "none";
+    hideExportPanel();
   });
 
   // Close modal when clicking outside
-  window.addEventListener("click", (event) => {
-    if (event.target === exportModal) {
-      exportModal.style.display = "none";
+  exportPanel.addEventListener("click", (event) => {
+    if (event.target === exportPanel) {
+      hideExportPanel();
     }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && exportPanel.classList.contains("visible")) {
+      hideExportPanel();
+    }
+  });
+
+  exportProgressModal.addEventListener("click", (event) => {
     if (event.target === exportProgressModal) {
       exportProgressModal.style.display = "none";
     }
@@ -211,7 +228,7 @@ function initializeExportControls() {
   // Save configuration
   saveConfigBtn.addEventListener("click", () => {
     saveConfigFromModal();
-    exportModal.style.display = "none";
+    hideExportPanel();
   });
 
   // Export PNG


### PR DESCRIPTION
## Summary
- change export configuration dialog to aside panel with glassmorphism effect
- add new CSS rules for the panel
- update JavaScript to open and close the panel

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a5e812f80832fb481292edbd7c10e